### PR TITLE
Fix wrong number of arguments error

### DIFF
--- a/lib/thread_ancestors.rb
+++ b/lib/thread_ancestors.rb
@@ -1,5 +1,5 @@
 module ThreadAncestors
-  def initialize
+  def initialize(*)
     @_parent = Thread.current
     super
   end

--- a/spec/thread_ancestors_spec.rb
+++ b/spec/thread_ancestors_spec.rb
@@ -17,6 +17,12 @@ describe ThreadAncestors do
     end.join
   end
 
+  it "handles thread initialization with args" do
+    Thread.new(123) do
+      expect(Thread.current.parent).to equal(Thread.main)
+    end.join
+  end
+
   it "can access ancestors multiple layers deep" do
     Thread.new do
       Thread.new do


### PR DESCRIPTION
When initializing a new Thread with arguments a NoMethodError is raised
as the ThreadAncestors.initialize has no arguments specified.